### PR TITLE
Add stopPlayer method to stop current audio playback

### DIFF
--- a/android/src/main/java/expo/modules/twowayaudio/AudioEngine.kt
+++ b/android/src/main/java/expo/modules/twowayaudio/AudioEngine.kt
@@ -286,6 +286,17 @@ class AudioEngine (context: Context) {
         audioTrack.write(data, 0, data.size)
     }
 
+    fun stopPlayer() {
+        audioSampleQueue.clear()
+        if (audioTrack.playState == AudioTrack.PLAYSTATE_PLAYING) {
+            audioTrack.pause()
+            audioTrack.flush()
+            audioTrack.play()
+        }
+        isPlaying = false
+        onOutputVolumeCallback?.invoke(0.0F)
+    }
+
     fun bypassVoiceProcessing(bypass: Boolean) {
         if (bypass) {
             echoCanceler?.enabled = false

--- a/android/src/main/java/expo/modules/twowayaudio/ExpoTwoWayAudioModule.kt
+++ b/android/src/main/java/expo/modules/twowayaudio/ExpoTwoWayAudioModule.kt
@@ -62,6 +62,10 @@ class ExpoTwoWayAudioModule : Module() {
              audioEngine?.playPCMData(data)
          }
 
+         Function("stopPlayer") {
+             audioEngine?.stopPlayer()
+         }
+
          Function("bypassVoiceProcessing") { bypass: Boolean ->
              audioEngine?.bypassVoiceProcessing(bypass)
          }

--- a/ios/AudioEngine.swift
+++ b/ios/AudioEngine.swift
@@ -207,6 +207,10 @@ class AudioEngine {
         }
     }
 
+    func stopPlayer() {
+        speechPlayer.stop()
+        updateOutputVolume()
+    }
     
     private func createBuffer(from data: Data) -> AVAudioPCMBuffer? {
         let frameCount = UInt32(data.count) / 2 // 16-bit input = 2 bytes per frame

--- a/ios/ExpoTwoWayAudioModule.swift
+++ b/ios/ExpoTwoWayAudioModule.swift
@@ -110,6 +110,10 @@ public class ExpoTwoWayAudioModule: Module {
             self.audioEngine?.playPCMData(pcmData)
         }
 
+        Function("stopPlayer") {
+            self.audioEngine?.stopPlayer()
+        }
+
         Function("bypassVoiceProcessing") { (bypass: Bool) in
             self.audioEngine?.bypassVoiceProcessing(bypass)
         }

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,6 +9,10 @@ export function playPCMData(audioData: Uint8Array) {
   return ExpoTwoWayAudioModule.playPCMData(audioData);
 }
 
+export function stopPlayer() {
+  return ExpoTwoWayAudioModule.stopPlayer();
+}
+
 export function bypassVoiceProcessing(bypass: boolean) {
   return ExpoTwoWayAudioModule.bypassVoiceProcessing(bypass);
 }


### PR DESCRIPTION
This pull request adds a new feature to both the Android and iOS audio modules, allowing the audio player to be stopped programmatically from the JavaScript layer. The implementation includes native methods for stopping playback and updates the TypeScript API to expose this functionality.

**New stop player functionality:**

* Added a `stopPlayer` function to the TypeScript API in `src/core.ts`, which calls the native module's stop method.
* Implemented a `stopPlayer` method in the Android `AudioEngine` class that clears the audio queue, stops playback, and resets the output volume.
* Exposed the `stopPlayer` method as a callable function in the Android `ExpoTwoWayAudioModule` class.
* Implemented a `stopPlayer` method in the iOS `AudioEngine` class that stops the speech player and updates the output volume.
* Exposed the `stopPlayer` method as a callable function in the iOS `ExpoTwoWayAudioModule` class.