### PR TITLE
Fix iOS build error: replace legacy EXFatal with fatalError

### DIFF
--- a/ios/MicrophonePermissionRequester.swift
+++ b/ios/MicrophonePermissionRequester.swift
@@ -15,11 +15,7 @@ class MicrophonePermissionRequester: NSObject, EXPermissionsRequester {
     var status: EXPermissionStatus
 
     guard (Bundle.main.infoDictionary?["NSMicrophoneUsageDescription"]) != nil else {
-      EXFatal(EXErrorWithMessage("""
-        This app is missing NSMicrophoneUsageDescription, so audio services will fail.
-        Add one of these keys to your bundle's Info.plist.
-      """))
-      return ["status": EXPermissionStatusDenied]
+      fatalError("This app is missing NSMicrophoneUsageDescription, so audio services will fail. Add this key to your bundle's Info.plist.")
     }
 
     switch systemStatus {


### PR DESCRIPTION
## Summary
- Replace `EXFatal(EXErrorWithMessage(...))` with Swift's native `fatalError()` in `MicrophonePermissionRequester.swift`
- `EXFatal` and `EXErrorWithMessage` are legacy Objective-C APIs in ExpoModulesCore that are no longer bridged into Swift scope as of Expo SDK 55, causing iOS build failures

---

*This PR was prepared with AI assistance.*